### PR TITLE
Fix usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ Here is a simple `craco.config.js` example for `frag` (OpenGL Fragment Shader) f
 const rawLoader = require('craco-raw-loader')
 
 module.exports = {
-  webpack: {
     plugins: [
-     { plugin: rawLoader,
+     { 
+       plugin: rawLoader,
        options: { test: /\.frag$/ }
      }
-  ]
 }
 ```


### PR DESCRIPTION
I don't know if this was changed in craco, but the plugins should not be in the webpack config.